### PR TITLE
Update openlineage to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <maven.compiler.source>11</maven.compiler.source>
       <maven.compiler.target>11</maven.compiler.target>
-      <openLineageVersion>1.7.0</openLineageVersion>
+      <openLineageVersion>1.12.0</openLineageVersion>
       <spotless.version>2.41.1</spotless.version>
       <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
       <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
@@ -58,7 +58,7 @@
       </dependency>
       <dependency>
          <groupId>io.openlineage</groupId>
-         <artifactId>openlineage-spark</artifactId>
+         <artifactId>openlineage-spark_2.12</artifactId>
          <version>${openLineageVersion}</version>
       </dependency>
       <dependency>
@@ -164,7 +164,7 @@
                   <configuration>
                      <artifactSet>
                         <includes>
-                           <include>io.openlineage:openlineage-spark</include>
+                           <include>io.openlineage:openlineage-spark_2.12</include>
                         </includes>
                      </artifactSet>
                   </configuration>

--- a/src/main/java/org/openmetadata/spark/agent/OpenMetadataArgumentParser.java
+++ b/src/main/java/org/openmetadata/spark/agent/OpenMetadataArgumentParser.java
@@ -54,7 +54,8 @@ import scala.Tuple2;
 public class OpenMetadataArgumentParser {
 
   public static final String SPARK_CONF_NAMESPACE = "spark.openmetadata.namespace";
-  public static final String SPARK_CONF_JOB_NAME = "spark.openmetadata.parentJobName";
+  public static final String SPARK_CONF_PARENT_JOB_NAMESPACE = "spark.openmetadata.parentJobNamespace";
+  public static final String SPARK_CONF_PARENT_JOB_NAME = "spark.openmetadata.parentJobName";
   public static final String SPARK_CONF_PARENT_RUN_ID = "spark.openmetadata.parentRunId";
   public static final String SPARK_CONF_APP_NAME = "spark.openmetadata.appName";
   public static final String SPARK_CONF_DISABLED_FACETS = "spark.openmetadata.facets.disabled";
@@ -81,9 +82,10 @@ public class OpenMetadataArgumentParser {
     }
     findSparkConfigKey(conf, SPARK_CONF_APP_NAME)
         .filter(str -> !str.isEmpty())
-        .ifPresent(builder::appName);
+        .ifPresent(builder::overriddenAppName);
     findSparkConfigKey(conf, SPARK_CONF_NAMESPACE).ifPresent(builder::namespace);
-    findSparkConfigKey(conf, SPARK_CONF_JOB_NAME).ifPresent(builder::jobName);
+    findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAME).ifPresent(builder::parentJobName);
+    findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAMESPACE).ifPresent(builder::parentJobNamespace);
     findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID).ifPresent(builder::parentRunId);
     builder.openLineageYaml(OpenMetadataArgumentParser.extractOpenlineageConfFromSparkConf(conf));
     return builder.build();

--- a/src/main/java/org/openmetadata/spark/agent/OpenMetadataSparkListener.java
+++ b/src/main/java/org/openmetadata/spark/agent/OpenMetadataSparkListener.java
@@ -20,6 +20,8 @@ package org.openmetadata.spark.agent;
 
 import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptional;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.Environment;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.ArgumentParser;
@@ -74,6 +76,7 @@ public class OpenMetadataSparkListener extends org.apache.spark.scheduler.SparkL
   private static WeakHashMap<RDD<?>, Configuration> outputs = new WeakHashMap<>();
   private static ContextFactory contextFactory;
   private static JobMetricsHolder jobMetrics = JobMetricsHolder.getInstance();
+  private static MeterRegistry meterRegistry = new SimpleMeterRegistry(); // dummy registry
   private final Function1<SparkSession, SparkContext> sparkContextFromSession =
       ScalaConversionUtils.toScalaFn(SparkSession::sparkContext);
   private final Function0<Option<SparkContext>> activeSparkContext =
@@ -252,7 +255,9 @@ public class OpenMetadataSparkListener extends org.apache.spark.scheduler.SparkL
         .job(
             ol.newJobBuilder()
                 .namespace(contextFactory.openLineageEventEmitter.getJobNamespace())
-                .name(contextFactory.openLineageEventEmitter.getParentJobName())
+                .name(contextFactory.openLineageEventEmitter.getParentJobName()
+                    .orElse(contextFactory.openLineageEventEmitter.getApplicationJobName())
+                )
                 .build())
         .build();
   }
@@ -281,10 +286,18 @@ public class OpenMetadataSparkListener extends org.apache.spark.scheduler.SparkL
    */
   @Override
   public void onApplicationStart(SparkListenerApplicationStart applicationStart) {
-    initializeContextFactoryIfNotInitialized();
+    initializeContextFactoryIfNotInitialized(applicationStart.appName());
   }
 
   private void initializeContextFactoryIfNotInitialized() {
+    if (contextFactory != null || isDisabled) {
+      return;
+    }
+    asJavaOptional(activeSparkContext.apply())
+        .ifPresent(context -> initializeContextFactoryIfNotInitialized(context.appName()));
+  }
+
+  private void initializeContextFactoryIfNotInitialized(String appName) {
     if (contextFactory != null || isDisabled) {
       return;
     }
@@ -292,7 +305,7 @@ public class OpenMetadataSparkListener extends org.apache.spark.scheduler.SparkL
     if (sparkEnv != null) {
       try {
         ArgumentParser args = OpenMetadataArgumentParser.parse(sparkEnv.conf());
-        contextFactory = new ContextFactory(new EventEmitter(args));
+        contextFactory = new ContextFactory(new EventEmitter(args, appName), meterRegistry);
       } catch (URISyntaxException e) {
         log.error("Unable to parse open lineage endpoint. Lineage events will not be collected", e);
       }


### PR DESCRIPTION
Relates to #15 

This PR upgrades openlineage-spark to 1.12.0 for incorporating the additional features newer versions have to offer.

The PR considers the following, enabled by the upgrade, out of scope:

* Adding metrics support
* Adding support for scala 2.13