### PR TITLE
Update Agent for Latest OpenLineage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <maven.compiler.source>11</maven.compiler.source>
       <maven.compiler.target>11</maven.compiler.target>
-      <openLineageVersion>1.12.0</openLineageVersion>
+      <openLineageVersion>1.47.1</openLineageVersion>
       <spotless.version>2.41.1</spotless.version>
       <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
       <maven-source-plugin.version>3.3.0</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
       <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
       <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
       <sparkVersion>3.5.0</sparkVersion>
+      <scalaVersion>2.12</scalaVersion>
    </properties>
    <dependencies>
       <dependency>
@@ -60,7 +61,7 @@
       </dependency>
       <dependency>
          <groupId>io.openlineage</groupId>
-         <artifactId>openlineage-spark_2.12</artifactId>
+         <artifactId>openlineage-spark_${scalaVersion}</artifactId>
          <version>${openLineageVersion}</version>
       </dependency>
       <dependency>
@@ -108,7 +109,7 @@
       <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core -->
       <dependency>
          <groupId>org.apache.spark</groupId>
-         <artifactId>spark-sql_2.12</artifactId>
+         <artifactId>spark-sql_${scalaVersion}</artifactId>
          <version>${sparkVersion}</version>
       </dependency>
    </dependencies>
@@ -166,7 +167,7 @@
                   <configuration>
                      <artifactSet>
                         <includes>
-                           <include>io.openlineage:openlineage-spark_2.12</include>
+                           <include>io.openlineage:openlineage-spark_${scalaVersion}</include>
                         </includes>
                      </artifactSet>
                   </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,9 @@
       <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
       <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
       <sparkVersion>3.5.0</sparkVersion>
-      <scalaVersion>2.12</scalaVersion>
+      <scalaVersion>2.13</scalaVersion>
    </properties>
    <dependencies>
-      <dependency>
-         <groupId>io.openlineage</groupId>
-         <artifactId>openlineage-java</artifactId>
-         <version>${openLineageVersion}</version>
-      </dependency>
       <dependency>
          <groupId>io.openlineage</groupId>
          <artifactId>openlineage-spark_${scalaVersion}</artifactId>
@@ -170,6 +165,9 @@
                            <include>io.openlineage:openlineage-spark_${scalaVersion}</include>
                         </includes>
                      </artifactSet>
+                     <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                     </transformers>
                   </configuration>
                </execution>
             </executions>

--- a/src/main/java/org/openmetadata/spark/agent/OpenMetadataArgumentParser.java
+++ b/src/main/java/org/openmetadata/spark/agent/OpenMetadataArgumentParser.java
@@ -20,16 +20,14 @@ package org.openmetadata.spark.agent;
 
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKey;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openlineage.client.OpenLineageClientUtils;
-import io.openlineage.client.OpenLineageYaml;
-import io.openlineage.spark.agent.ArgumentParser;
-import io.openlineage.spark.agent.ArgumentParser.ArgumentParserBuilder;
 import io.openlineage.spark.agent.UrlParser;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -72,8 +70,7 @@ public class OpenMetadataArgumentParser {
   public static final String SPARK_CONF_CUSTOM_ENVIRONMENT_VARIABLES =
       "spark.openmetadata.facets.custom_environment_variables";
 
-  public static ArgumentParser parse(SparkConf conf) {
-    ArgumentParserBuilder builder = ArgumentParser.builder();
+  public static SparkOpenLineageConfig parse(SparkConf conf) {
     conf.setIfMissing(SPARK_CONF_DISABLED_FACETS, DEFAULT_DISABLED_FACETS);
     conf.setIfMissing(SPARK_CONF_TRANSPORT_TYPE, "console");
 
@@ -81,19 +78,19 @@ public class OpenMetadataArgumentParser {
       findSparkConfigKey(conf, SPARK_CONF_HTTP_URL)
           .ifPresent(url -> UrlParser.parseUrl(url).forEach(conf::set));
     }
+    SparkOpenLineageConfig config = extractOpenLineageConfFromSparkConf(conf);
     findSparkConfigKey(conf, SPARK_CONF_APP_NAME)
         .filter(str -> !str.isEmpty())
-        .ifPresent(builder::overriddenAppName);
-    findSparkConfigKey(conf, SPARK_CONF_NAMESPACE).ifPresent(builder::namespace);
-    findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAME).ifPresent(builder::parentJobName);
+        .ifPresent(config::setOverriddenAppName);
+    findSparkConfigKey(conf, SPARK_CONF_NAMESPACE).ifPresent(config::setNamespace);
+    findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAME).ifPresent(config::setParentJobName);
     findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAMESPACE)
-        .ifPresent(builder::parentJobNamespace);
-    findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID).ifPresent(builder::parentRunId);
-    builder.openLineageYaml(OpenMetadataArgumentParser.extractOpenlineageConfFromSparkConf(conf));
-    return builder.build();
+        .ifPresent(config::setParentJobNamespace);
+    findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID).ifPresent(config::setParentRunId);
+    return config;
   }
 
-  public static OpenLineageYaml extractOpenlineageConfFromSparkConf(SparkConf conf) {
+  public static SparkOpenLineageConfig extractOpenLineageConfFromSparkConf(SparkConf conf) {
     List<Tuple2<String, String>> properties = filterProperties(conf);
     ObjectMapper objectMapper = new ObjectMapper();
     ObjectNode objectNode = objectMapper.createObjectNode();
@@ -125,9 +122,10 @@ public class OpenMetadataArgumentParser {
       }
     }
     try {
-      return OpenLineageClientUtils.loadOpenLineageYaml(
-          new ByteArrayInputStream(objectMapper.writeValueAsBytes(objectNode)));
-    } catch (IOException e) {
+      return OpenLineageClientUtils.loadOpenLineageConfigJson(
+          new ByteArrayInputStream(objectMapper.writeValueAsBytes(objectNode)),
+          new TypeReference<SparkOpenLineageConfig>() {});
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/org/openmetadata/spark/agent/OpenMetadataArgumentParser.java
+++ b/src/main/java/org/openmetadata/spark/agent/OpenMetadataArgumentParser.java
@@ -20,11 +20,11 @@ package org.openmetadata.spark.agent;
 
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKey;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.spark.shaded.com.fasterxml.jackson.core.type.TypeReference;
+import io.openlineage.spark.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import io.openlineage.spark.shaded.com.fasterxml.jackson.databind.node.ArrayNode;
+import io.openlineage.spark.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openlineage.spark.agent.UrlParser;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.io.ByteArrayInputStream;

--- a/src/main/java/org/openmetadata/spark/agent/OpenMetadataSparkListener.java
+++ b/src/main/java/org/openmetadata/spark/agent/OpenMetadataSparkListener.java
@@ -24,13 +24,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.Environment;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.ArgumentParser;
 import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.JobMetricsHolder;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.ContextFactory;
 import io.openlineage.spark.agent.lifecycle.ExecutionContext;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
@@ -306,8 +306,9 @@ public class OpenMetadataSparkListener extends org.apache.spark.scheduler.SparkL
     SparkEnv sparkEnv = SparkEnv$.MODULE$.get();
     if (sparkEnv != null) {
       try {
-        ArgumentParser args = OpenMetadataArgumentParser.parse(sparkEnv.conf());
-        contextFactory = new ContextFactory(new EventEmitter(args, appName), meterRegistry);
+        SparkOpenLineageConfig config = OpenMetadataArgumentParser.parse(sparkEnv.conf());
+        contextFactory =
+            new ContextFactory(new EventEmitter(config, appName), meterRegistry, config);
       } catch (URISyntaxException e) {
         log.error("Unable to parse open lineage endpoint. Lineage events will not be collected", e);
       }

--- a/src/main/java/org/openmetadata/transport/OpenMetadataTransport.java
+++ b/src/main/java/org/openmetadata/transport/OpenMetadataTransport.java
@@ -519,7 +519,7 @@ public final class OpenMetadataTransport extends Transport implements Closeable 
     return createPutRequest("/api/v1/pipelines", jsonRequest);
   }
 
-  public String extractDbNameFromUrl(String url) {
+  public static String extractDbNameFromUrl(String url) {
     if (url != null) {
       Pattern pattern = Pattern.compile("^[^:]+://[^/]+:[0-9]+/([^?]+)");
       Matcher matcher = pattern.matcher(url);

--- a/src/main/java/org/openmetadata/transport/OpenMetadataTransport.java
+++ b/src/main/java/org/openmetadata/transport/OpenMetadataTransport.java
@@ -125,6 +125,16 @@ public final class OpenMetadataTransport extends Transport implements Closeable 
   }
 
   @Override
+  public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
+    log.debug("DatasetEvent emit is not supported by OpenMetadataTransport");
+  }
+
+  @Override
+  public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
+    log.debug("JobEvent emit is not supported by OpenMetadataTransport");
+  }
+
+  @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     try {
       log.debug(

--- a/src/test/java/org/openmetadata/transport/OpenMetadataTransportTest.java
+++ b/src/test/java/org/openmetadata/transport/OpenMetadataTransportTest.java
@@ -7,20 +7,18 @@ public class OpenMetadataTransportTest {
   @Test
   public void testExtractDbNameFromRedshiftUrl() {
     String result =
-        createOpenMetadataTransport().extractDbNameFromUrl("redshift://localhost:5439/warehouse");
-    Assert.assertEquals("public", result);
+        OpenMetadataTransport
+            .extractDbNameFromUrl(
+                "redshift://localhost:5439/warehouse");
+    Assert.assertEquals("warehouse", result);
   }
 
   @Test
   public void testExtractDbNameFromMysqlUrl() {
     String result =
-        createOpenMetadataTransport()
+        OpenMetadataTransport
             .extractDbNameFromUrl(
                 "mysql://localhost:3306/experiments?serverTimezone=UTC&rewriteBatchedStatements=true&useSSL=false");
     Assert.assertEquals("experiments", result);
-  }
-
-  private OpenMetadataTransport createOpenMetadataTransport() {
-    return new OpenMetadataTransport(new OpenMetadataConfig());
   }
 }


### PR DESCRIPTION
Update the agent so that it builds with the latest OpenLineage JAR as it's had some API changes. With this PR we also parameterize the Scala version that is built so that it can be switched depending on the target Spark / Scala combo.